### PR TITLE
Add deletion function with cache busting and fix tag updating.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,8 @@ module.exports = {
   ],
   rules: {
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off'
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    'object-property-newline': 'off'
   },
   parserOptions: {
     parser: 'babel-eslint'

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -7,3 +7,9 @@ export const parseToken = (token) => {
 }
 
 export const googleToGeoJSON = ({ location }) => ({ type: 'Point', coordinates: [location.lng, location.lat] })
+
+/* Change tags to a relation and filter out restricted tags */
+/* This is non-authoritative, and would just cause an error if the user tried to write special tags */
+export const SPECIAL_TAG_IDS = [4]
+/* eslint-disable-next-line camelcase */
+export const filterSpecialTags = ({ tag_id }) => !SPECIAL_TAG_IDS.includes(tag_id)

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -145,7 +145,12 @@ mutation (
   $tags: [businesses_tags_insert_input!]!
   $territories: [businesses_territories_insert_input!]!
 ) {
-  delete_businesses_tags(where:{business_id:{_eq:$business_id}}) {
+  delete_businesses_tags( where: {
+    _and: [
+      {business_id:{_eq:$business_id}},
+      {_not: { tag: { name: { _eq: "featured" } } } }
+    ]
+  }) {
     affected_rows,
     returning {
       business {
@@ -181,6 +186,14 @@ mutation (
     id name short_description long_description
     territories { territory { id, name, description_url }}
   }
+}`
+
+export const DELETE_BUSINESS = gql`
+mutation($business_id: uuid!) {
+  update_businesses_by_pk(
+    pk_columns: { id: $business_id }
+    _set: { deleted: true }
+  ) { id, name }
 }`
 
 /* Automaticaly sets owner id and business id on backend */

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -143,12 +143,13 @@ mutation (
   $business_id: uuid!
   $business: businesses_set_input!
   $tags: [businesses_tags_insert_input!]!
+  $ignore_delete_tags: [bigint!]!
   $territories: [businesses_territories_insert_input!]!
 ) {
   delete_businesses_tags( where: {
     _and: [
-      {business_id:{_eq:$business_id}},
-      {_not: { tag: { name: { _eq: "featured" } } } }
+      {business_id: {_eq:$business_id}},
+      {_not: { tag_id: { _in: $ignore_delete_tags } }}
     ]
   }) {
     affected_rows,

--- a/src/views/owner/EditBusiness.vue
+++ b/src/views/owner/EditBusiness.vue
@@ -114,10 +114,13 @@
         </div>
       </transition>
       <button
-        class="text-green-500 px-6 py-2 mr-4 border hover:bg-green-500 hover:text-white transition-colors duration-150 rounded"
+        class="text-green-500 px-6 py-2 mr-4 border border-green-500 hover:bg-green-500 hover:text-white transition-colors duration-150 rounded"
         @click="saveBusiness"
       >Save</button>
-      <button class="text-red-500 text-white py-2 underline hover:no-underline rounded" type="submit">Delete</button>
+      <button
+        class="text-red-500 text-white py-2 underline hover:no-underline rounded"
+        @click="deleteBusiness"
+      >Delete</button>
     </div>
     <h1 class="text-2xl">Business Preview</h1>
     <BusinessCard :business="business" />
@@ -139,7 +142,8 @@ import {
   GET_BUSINESS_BY_ID,
   GET_ALL_TAGS,
   GET_ALL_TERRITORIES,
-  SAVE_BUSINESS
+  SAVE_BUSINESS,
+  DELETE_BUSINESS
 } from '@/queries'
 
 export default {
@@ -229,6 +233,24 @@ export default {
         })
       } catch (e) {
         this.saveState = SaveStates.ERROR
+      }
+    },
+    async deleteBusiness () {
+      if (confirm('Are you sure you want to delete this business?')) {
+        await this.$apollo.mutate({
+          mutation: DELETE_BUSINESS,
+          context: CONTEXT_LOGGED_IN,
+          variables: {
+            business_id: this.business.id
+          },
+          update: async (cache, { data }) => {
+            const routeChange = await this.$router.push({ name: 'owner-home' })
+            console.log(routeChange)
+            /* Force re-fetching of businesses after deletion */
+            const component = routeChange.matched[0].instances.default
+            component.$apollo.queries.businesses.refetch()
+          }
+        })
       }
     },
     async geocode (address) {

--- a/src/views/owner/EditBusiness.vue
+++ b/src/views/owner/EditBusiness.vue
@@ -132,7 +132,7 @@ import LabeledInput from '@/components/ui/LabeledInput'
 import LabeledField from '@/components/ui/LabeledField'
 import Map from '@/components/business/Map'
 
-import { googleToGeoJSON } from '@/helpers'
+import { googleToGeoJSON, filterSpecialTags, SPECIAL_TAG_IDS } from '@/helpers'
 import { CONTEXT_LOGGED_IN, SaveStates } from '@/constants'
 
 import { mapState } from 'vuex'
@@ -172,7 +172,7 @@ export default {
 
     tags_edit: {
       get () {
-        return this.business.tags.map(i => i.tag)
+        return this.business.tags.filter(filterSpecialTags).map(i => i.tag)
       },
       set (values) {
         this.business.tags = values.map(tag => ({
@@ -210,6 +210,10 @@ export default {
       /* eslint-disable camelcase */
       let { id, name, short_description, long_description, external_url, location, physical_address, tags, territories } = this.business
       let business = { name, short_description, long_description, external_url, location, physical_address }
+
+      tags = tags.filter(filterSpecialTags).map(({ tag_id, business_id }) => ({ tag_id, business_id }))
+      territories = territories.map(({ territory_id, business_id }) => ({ territory_id, business_id }))
+
       this.saveState = SaveStates.SAVING
 
       try {
@@ -217,10 +221,9 @@ export default {
           mutation: SAVE_BUSINESS,
           context: CONTEXT_LOGGED_IN,
           variables: {
-            business,
             business_id: id,
-            tags: tags.map(({ tag_id, business_id }) => ({ tag_id, business_id })),
-            territories: territories.map(({ territory_id, business_id }) => ({ territory_id, business_id }))
+            ignore_delete_tags: SPECIAL_TAG_IDS,
+            business, tags, territories
           },
           update: (cache, { data }) => {
             const business = data.update_businesses_by_pk.business

--- a/src/views/owner/Home.vue
+++ b/src/views/owner/Home.vue
@@ -6,9 +6,7 @@
         Add Business
       </button>
     </section>
-    <section v-for="business in businesses" :key="business.id">
-      <BusinessCard :business="business" />
-    </section>
+    <BusinessCard :business="business" v-for="business in businesses" :key="business.id" />
   </main>
 </template>
 <script>
@@ -29,12 +27,14 @@ export default {
       query: GET_LOGGED_IN_USER_BUSINESSES,
       variables () {
         return { owner_id: this.user.sub }
+      },
+      skip () {
+        return !this.user
       }
     }
   },
   methods: {
     async addBusiness () {
-      console.log('ok')
       try {
         await this.$apollo.mutate({
           mutation: CREATE_BUSINESS,


### PR DESCRIPTION
You can now delete businesses!
- Businesses marked as `deleted` in the backend, and can be cleaned up by a cron job after some number of days in the future.
- I've opted to use the default javascript / in-browser modal, as it works on every browser, is design agnostic, is super simple, and adds no tech debt trying to add some silly vue package that has shiny models. Maybe some day in the future, but I'm satisfied with this for now.
- Users are redirected to their business lists after deletion.

## Bug Fixes
-  I've fixed a bug where users could not update businesses when they are featured since users cannot reassign the `featured` tag (only admins can). This is because of Hasura's lack of list-relation updates (you have to delete and reinsert all relations in one transaction), but should be simplified some day in the future. This fix works for now!
- Fixed console errors thrown when a query is attempted before the component has user info from the JWT using the `skip` parameter.